### PR TITLE
'/tts_stream' - synchronize TTS generation to prevent model crashes

### DIFF
--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -14,6 +14,7 @@ from loguru import logger
 from argparse import ArgumentParser
 from pathlib import Path
 from uuid import uuid4
+import asyncio
 
 from xtts_api_server.tts_funcs import TTSWrapper,supported_languages,InvalidSettingsError
 from xtts_api_server.RealtimeTTS import TextToAudioStream, CoquiEngine
@@ -36,6 +37,9 @@ USE_CACHE = os.getenv("USE_CACHE") == 'true'
 STREAM_MODE = os.getenv("STREAM_MODE") == 'true'
 STREAM_MODE_IMPROVE = os.getenv("STREAM_MODE_IMPROVE") == 'true'
 STREAM_PLAY_SYNC = os.getenv("STREAM_PLAY_SYNC") == 'true'
+
+# global lock for synchronized TTS generation
+tts_lock = asyncio.Lock()
 
 if(DEEPSPEED):
   install_deepspeed_based_on_python_version()
@@ -223,30 +227,27 @@ def set_tts_settings_endpoint(tts_settings_req: TTSSettingsRequest):
 
 @app.get('/tts_stream')
 async def tts_stream(request: Request, text: str = Query(), speaker_wav: str = Query(), language: str = Query()):
-    # Validate local model source.
     if XTTS.model_source != "local":
-        raise HTTPException(status_code=400,
-                            detail="HTTP Streaming is only supported for local models.")
-    # Validate language code against supported languages.
+        raise HTTPException(status_code=400, detail="HTTP Streaming is only supported for local models.")
+    
     if language.lower() not in supported_languages:
-        raise HTTPException(status_code=400,
-                            detail="Language code sent is either unsupported or misspelled.")
-            
+        raise HTTPException(status_code=400, detail="Language code sent is either unsupported or misspelled.")
+
     async def generator():
-        chunks = XTTS.process_tts_to_file(
-            text=text,
-            speaker_name_or_path=speaker_wav,
-            language=language.lower(),
-            stream=True,
-        )
-        # Write file header to the output stream.
-        yield XTTS.get_wav_header()
-        async for chunk in chunks:
-            # Check if the client is still connected.
-            disconnected = await request.is_disconnected()
-            if disconnected:
-                break
-            yield chunk
+        # wait until the lock is available
+        async with tts_lock:
+            chunks = XTTS.process_tts_to_file(
+                text=text,
+                speaker_name_or_path=speaker_wav,
+                language=language.lower(),
+                stream=True,
+            )
+            yield XTTS.get_wav_header()
+            async for chunk in chunks:
+                disconnected = await request.is_disconnected()
+                if disconnected:
+                    break
+                yield chunk
 
     return StreamingResponse(generator(), media_type='audio/x-wav')
 


### PR DESCRIPTION
### Synchronize `/tts_stream` generation to prevent concurrent model crashes

This PR introduces a global `asyncio.Lock` in the `/tts_stream` endpoint to ensure that only one request at a time can perform TTS audio **generation**.

Previously, sending multiple `/tts_stream` requests in parallel could cause the underlying model to crash due to concurrent generation attempts. With this change, requests now wait for the current generation to finish before starting a new one.

**Key points:**

* Added a shared `asyncio.Lock` around the generation logic.
* Only the generation process is synchronized — audio **playback** of already-generated streams remains concurrent.
* No changes to API parameters or response format.

**Why:**
Prevent model crashes and ensure stability when multiple clients attempt to generate speech at the same time.